### PR TITLE
Generate Gemfile.lock with newer versions.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    puma (3.10.0)
-    rack (2.0.3)
+    puma (3.12.0)
+    rack (2.0.6)
 
 PLATFORMS
   ruby
@@ -12,4 +12,4 @@ DEPENDENCIES
   rack
 
 BUNDLED WITH
-   1.11.2
+   1.16.4


### PR DESCRIPTION
```
$ oc logs -f bc/ruby-ex
Cloning "https://github.com/pvalena/ruby-ex.git" ...
        Commit: 62819b87a2fd9a3c70a8f656f8d0d75918e0b6b7 (Generate Gemfile.lock with newer versions.)
        Author: Pavel Valena <pvalena@redhat.com>
        Date:   Mon Dec 3 17:55:58 2018 +0100
Using 172.30.1.1:5000/openshift/ruby@sha256:20124630b4a72d4dcc41064ebfbe586d2abba45748644672e273a4fd9dd0fb03 as the s2i builder image
---> Installing application source ...
---> Building your Ruby application from source ...
---> Running 'bundle install --retry 2 --deployment --without development:test' ...
Warning: the running version of Bundler (1.16.1) is older than the version that created the lockfile (1.16.4). We suggest you upgrade to the latest version of Bundler by running `gem install bundler`.
Fetching gem metadata from https://rubygems.org/..............
Using bundler 1.16.1
Fetching puma 3.12.0
Installing puma 3.12.0 with native extensions
Fetching rack 2.0.6
Installing rack 2.0.6
Bundle complete! 2 Gemfile dependencies, 3 gems now installed.
Gems in the groups development and test were not installed.
Bundled gems are installed into `./bundle`
---> Cleaning up unused ruby gems ...
Running `bundle clean --verbose` with bundler 1.16.1
Warning: the running version of Bundler (1.16.1) is older than the version that created the lockfile (1.16.4). We suggest you upgrade to the latest version of Bundler by running `gem install bundler`.
Frozen, using resolution from the lockfile

Pushing image 172.30.1.1:5000/test-ruby-ex-9/ruby-ex:latest ...
Pushed 1/6 layers, 18% complete
Pushed 2/6 layers, 33% complete
Push successful

$ curl -s ruby-ex-test-ruby-ex-9.127.0.0.1.nip.io | grep 'Ruby a'
            <h1>Welcome to your Ruby application on OpenShift</h1>
```