### PR TITLE
Update Gemfile.lock to newer version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,10 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    puma (3.12.0)
-    rack (2.0.6)
+    nio4r (2.5.2)
+    puma (4.3.5)
+      nio4r (~> 2.0)
+    rack (2.2.3)
 
 PLATFORMS
   ruby
@@ -12,4 +14,4 @@ DEPENDENCIES
   rack
 
 BUNDLED WITH
-   1.16.4
+   2.1.4


### PR DESCRIPTION
When execute command: "oc new-app ruby~https://github.com/sclorg/ruby-ex" met error as belllow, most of our auto cases failed with it, so submit the pr,  @adambkaplan @openshift/devexp-qe please check it, [pass log ](http://pastebin.test.redhat.com/890197) thanks
```
STEP 8: RUN /usr/libexec/s2i/assemble
---> Installing application source ...
---> Building your Ruby application from source ...
---> Running 'bundle install --retry 2 --deployment --without development:test' ...
/opt/rh/rh-ruby27/root/usr/share/rubygems/rubygems.rb:275:in `find_spec_for_exe': Could not find 'bundler' (1.16.4) required by your /opt/app-root/src/Gemfile.lock. (Gem::GemNotFoundException)
To update to the latest version installed on your system, run `bundle update --bundler`.
To install the missing version, run `gem install bundler:1.16.4`
	from /opt/rh/rh-ruby27/root/usr/share/rubygems/rubygems.rb:294:in `activate_bin_path'
	from /opt/rh/rh-ruby27/root/usr/bin/bundle:23:in `<main>'
subprocess exited with status 1
subprocess exited with status 1
error: build error: error building at STEP "RUN /usr/libexec/s2i/assemble": exit status 1
```
fyi: now  ruby:latest is point to 2.7 in openshift project