### PR TITLE
Update rack to 2.2.10 to fix error with Ruby 3.3 regexp.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    nio4r (2.5.2)
+    nio4r (2.5.9)
     puma (4.3.5)
       nio4r (~> 2.0)
-    rack (2.2.3)
+    rack (2.2.10)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
Ruby 3.3's Regexp class removed the third argument for #new and similar calls

Update nio4r, it didn't compile with Ruby 3.3.6. After update it still compiles with Ruby 2.5.

Updated only patch version of the gems. Puma seems to be working.